### PR TITLE
Changed how semiangle, defocus, rotation are printed in ptycho02_MoS2.ipynb

### DIFF
--- a/notebooks/ptycho02_MoS2.ipynb
+++ b/notebooks/ptycho02_MoS2.ipynb
@@ -644,13 +644,13 @@
    ],
    "source": [
     "semiangle_cutoff = dataset.calibration.get_Q_pixel_size() * probe_radius_pixels\n",
-    "print('semiangle cutoff estimate = ' + str(np.round(semiangle_cutoff,decimals=1)) + ' mrads')\n",
+    "print(f'semiangle cutoff estimate = {semiangle_cutoff:.1f} mrads')\n",
     "\n",
     "defocus = parallax.aberration_C1\n",
-    "print('estimated defocus         = ' + str(np.round(defocus*-1)) + ' Angstroms')\n",
+    "print(f'estimated defocus         = {defocus*-1:.1f} Angstroms')\n",
     "\n",
     "rotation_degrees = np.rad2deg(parallax.rotation_Q_to_R_rads)\n",
-    "print('estimated rotation        = ' + str(np.round(rotation_degrees)) + ' deg')"
+    "print(f'estimated rotation        = {rotation_degrees:.1f} deg')"
    ]
   },
   {


### PR DESCRIPTION
Print those values using f-strings instead of rounding and str().

The diff should look okay if you set it to "Hide whitespace", otherwise the diff is large.  I am guessing the line endings don't match somehow...